### PR TITLE
Add Global Top Bar With Dynamic Screen Name And Back Icon 

### DIFF
--- a/app/src/main/java/com/praveenpayasi/headlinehub/ui/MainActivity.kt
+++ b/app/src/main/java/com/praveenpayasi/headlinehub/ui/MainActivity.kt
@@ -13,42 +13,43 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.core.content.ContextCompat
+import androidx.navigation.compose.rememberNavController
+import com.praveenpayasi.headlinehub.ui.base.GlobalTopBar
 import com.praveenpayasi.headlinehub.ui.base.NewsNavHost
+import com.praveenpayasi.headlinehub.ui.base.rememberHeadlineHubAppState
 import com.praveenpayasi.headlinehub.ui.theme.NewsAppTheme
 import com.praveenpayasi.headlinehub.ui.theme.gray40
-import com.praveenpayasi.headlinehub.ui.utils.AppConstant
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
-    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         askNotificationPermission()
         setContent {
+            val navController = rememberNavController()
+            val appState = rememberHeadlineHubAppState(navController)
+
             NewsAppTheme {
-                Scaffold(topBar = {
-                    TopAppBar(colors = TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        titleContentColor = Color.White
-                    ), title = { Text(text = AppConstant.APP_NAME) })
-                }) { padding ->
+                Scaffold(
+                    topBar = {
+                        GlobalTopBar(
+                            title = appState.showScreenTitle,
+                            shouldShowBackIcon = appState.shouldShowBackIcon,
+                            onBackClick = navController::popBackStack
+                        )
+                    }
+                ) { padding ->
                     Column(
                         modifier = Modifier
                             .padding(padding)
                             .background(gray40),
                     ) {
-                        NewsNavHost()
+                        NewsNavHost(navController)
                     }
                 }
 

--- a/app/src/main/java/com/praveenpayasi/headlinehub/ui/base/CommonUI.kt
+++ b/app/src/main/java/com/praveenpayasi/headlinehub/ui/base/CommonUI.kt
@@ -11,12 +11,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,6 +31,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -170,5 +176,41 @@ fun SourceText(source: Source) {
         color = Color.Gray,
         maxLines = 1,
         modifier = Modifier.padding(start = 4.dp, end = 4.dp, top = 4.dp, bottom = 8.dp)
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GlobalTopBar(
+    title: String,
+    shouldShowBackIcon: Boolean = true,
+    onBackClick: () -> Unit,
+) {
+    TopAppBar(
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            titleContentColor = MaterialTheme.colorScheme.onPrimary,
+        ),
+        title = { Text(text = title) },
+        navigationIcon = {
+            if (shouldShowBackIcon)
+                Icon(
+                    modifier = Modifier.clickable { onBackClick() },
+                    imageVector = Icons.Default.ArrowBack,
+                    contentDescription = "ArrowBack",
+                    tint = MaterialTheme.colorScheme.onPrimary
+                )
+        }
+    )
+
+}
+
+@Preview(showBackground = true, apiLevel = 33)
+@Composable
+fun GlobalTopBarPreview() {
+    GlobalTopBar(
+        title = "Top Headlines",
+        shouldShowBackIcon = true,
+        onBackClick = {}
     )
 }

--- a/app/src/main/java/com/praveenpayasi/headlinehub/ui/base/HeadlineHubState.kt
+++ b/app/src/main/java/com/praveenpayasi/headlinehub/ui/base/HeadlineHubState.kt
@@ -1,0 +1,57 @@
+package com.praveenpayasi.headlinehub.ui.base
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.praveenpayasi.headlinehub.R
+
+
+/**
+ * The HeadlineHubState class manages navigation-related state in the HeadlineHub app.
+ * It determines whether to display a back icon in the app bar and provides
+ * the title of the current screen. The rememberHeadlineHubAppState function
+ * initializes and retains the app state across recompositions.
+ * */
+@Composable
+fun rememberHeadlineHubAppState(
+    navController: NavHostController,
+): HeadlineHubState {
+    return remember(navController) {
+        HeadlineHubState(navController)
+    }
+}
+
+class HeadlineHubState(
+    private val navController: NavHostController,
+) {
+
+    private val currentDestination: NavDestination?
+        @Composable get() = navController
+            .currentBackStackEntryAsState().value?.destination
+
+
+    val shouldShowBackIcon: Boolean
+        @Composable get() = when (currentDestination?.route) {
+            Route.HomeScreen.name -> false
+            else -> true
+        }
+
+
+    val showScreenTitle: String
+        @Composable get() = when (navController.currentDestination?.route) {
+            Route.HomeScreen.name -> stringResource(id = R.string.app_name)
+            Route.TopHeadline.name -> stringResource(id = R.string.top_headlines)
+            Route.PaginationTopHeadline.name -> stringResource(id = R.string.pagination_top_headlines)
+            Route.OfflineTopHeadline.name -> stringResource(id = R.string.offline_top_headlines)
+            Route.NewsSources.name -> stringResource(id = R.string.news_sources)
+            Route.CountryList.name -> stringResource(id = R.string.countries)
+            Route.LanguageList.name -> stringResource(id = R.string.language)
+            Route.Search.name -> stringResource(id = R.string.search)
+            else -> ""
+        }
+
+
+}

--- a/app/src/main/java/com/praveenpayasi/headlinehub/ui/base/Navigation.kt
+++ b/app/src/main/java/com/praveenpayasi/headlinehub/ui/base/Navigation.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -47,9 +48,9 @@ sealed class Route(val name: String) {
 }
 
 @Composable
-fun NewsNavHost() {
+fun NewsNavHost(navController: NavHostController) {
 
-    val navController = rememberNavController()
+
     val context = LocalContext.current
 
     NavHost(


### PR DESCRIPTION
This pull request introduces the GlobalTopBar fun, which enables the creation of a top app bar with a dynamic screen title and an optional back icon. The GlobalTopBar function supports customization of the screen title, allowing for dynamic updates based on the current screen context. These changes enhance the user experience by providing a consistent and adaptable navigation component across different screens within the HeadlineHub app.